### PR TITLE
Remove double render deprecations

### DIFF
--- a/addon/mixins/registrable.js
+++ b/addon/mixins/registrable.js
@@ -1,9 +1,18 @@
 import Ember from 'ember';
 import FloatLabel from 'ember-float-label/components/float-label';
 
+const {
+  on,
+  run: { scheduleOnce }
+} = Ember;
+
 export default Ember.Mixin.create({
-  _registerWithFloatLabel: function() {
+  _registerWithFloatLabel: on('init', function() {
     var parent = this.get('parentView');
-    if (parent instanceof FloatLabel) { parent.send('register', this); }
-  }.on('init')
+    if (parent instanceof FloatLabel) {
+      scheduleOnce('afterRender', () => {
+        parent.send('register', this);
+      });
+    }
+  })
 });

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.9",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0"
   }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,3 +1,9 @@
 <h2 id="title">Welcome to Ember</h2>
 
-{{outlet}}
+{{#float-label}}
+  {{input type="text" value=name placeholder="Name"}}
+{{/float-label}}
+
+{{#float-label}}
+  {{textarea value=notes placeholder="Notes"}}
+{{/float-label}}


### PR DESCRIPTION
Great addon!

This fixes #2.

Wrapping the `parent.send` in the `scheduleOnce` is all that is needed. The `on('init')` change and pinning jquery is so the dummy page would work.
